### PR TITLE
Fix clang-cl build failure in Azure Pipelines 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ build
 build-*
 
 .vscode
-
+.vs
 *.zip
 
 # Created by https://www.toptal.com/developers/gitignore/api/conan,cmake,python,c++,visualstudiocode

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -93,18 +93,6 @@
             }
         },
         {
-            "name": "x86-clang-debug-vs2019",
-            "displayName": "vs2019/x86(clang-cl)/debug",
-            "generator": "Ninja",
-            "inherits": "x86-clang-debug"
-        },
-        {
-            "name": "x64-clang-debug-vs2019",
-            "displayName": "vs2019/x64(clang-cl)/debug",
-            "generator": "Ninja",
-            "inherits": "x64-clang-debug"
-        },
-        {
             "name": "x64-osx-debug",
             "displayName": "x64-osx/debug",
             "generator": "Ninja",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,11 +63,20 @@ jobs:
           command: "install"
           installPackageId: "ninja"
           installInstallArgs: "--no-progress --yes"
-      - task: CMake@1
-        displayName: "CMake: Configure"
-        inputs:
-          cmakeArgs: --preset $(cmake.preset)
-          workingDirectory: "."
+      # see https://www.cicoria.com/using-vcvars64-vcvars-bat-from-powershell-and-azure-devops/
+      # see https://github.com/Microsoft/azure-pipelines-tasks/issues/9737
+      - powershell: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $installPath = &$vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          # &$installPath\VC\Auxiliary\Build\vcvarsall.bat x86
+          echo "##vso[task.setvariable variable=vcvarsPath;isOutput=true]$installPath\VC\Auxiliary\Build\vcvarsall.bat"
+        name: detected
+        displayName: "PowerShell: Search vcvarsall.bat"
+      - powershell: |
+          Write-Output $detected.vcvarsPath
+          & $detected.vcvarsPath x86
+          cmake --preset x86-clang-debug -DCMAKE_INSTALL_PREFIX:PATH="$(Build.ArtifactStagingDirectory)"
+        displayName: "CMake: Configure(vcvarsall)"
       - task: CMake@1
         displayName: "CMake: Build"
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,12 +77,8 @@ jobs:
           echo $(detected.vcvarsPath)
           call "$(detected.vcvarsPath)" $(vcvars.arg)
           cmake --preset $(cmake.preset) -DCMAKE_INSTALL_PREFIX:PATH="$(Build.ArtifactStagingDirectory)"
-        displayName: "CMake: Configure(vcvarsall)"
-      - task: CMake@1
-        displayName: "CMake: Build"
-        inputs:
-          cmakeArgs: --build --preset $(cmake.preset)
-          workingDirectory: "."
+          cmake --build --preset $(cmake.preset)
+        displayName: "CMake: Configure/Build(vcvarsall)"
       - task: CMake@1
         displayName: "CMake: Install"
         inputs:
@@ -95,8 +91,10 @@ jobs:
     strategy:
       matrix:
         debug_x86:
+          vcvars.arg: x86
           cmake.preset: x86-clang-debug-vs2019
         debug_x64:
+          vcvars.arg: x64
           cmake.preset: x64-clang-debug-vs2019
     steps:
       - task: ChocolateyCommand@0
@@ -109,16 +107,18 @@ jobs:
           command: "install"
           installPackageId: "llvm"
           installInstallArgs: "--no-progress --yes"
-      - task: CMake@1
-        displayName: "CMake: Configure"
-        inputs:
-          cmakeArgs: --preset $(cmake.preset)
-          workingDirectory: "."
-      - task: CMake@1
-        displayName: "CMake: Build"
-        inputs:
-          cmakeArgs: --build --preset $(cmake.preset)
-          workingDirectory: "."
+      - powershell: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $installPath = &$vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          echo "##vso[task.setvariable variable=vcvarsPath;isOutput=true]$installPath\VC\Auxiliary\Build\vcvarsall.bat"
+        name: detected
+        displayName: "PowerShell: Search vcvarsall.bat"
+      - script: | # using Cmdlet
+          echo $(detected.vcvarsPath)
+          call "$(detected.vcvarsPath)" $(vcvars.arg)
+          cmake --preset $(cmake.preset) -DCMAKE_INSTALL_PREFIX:PATH="$(Build.ArtifactStagingDirectory)"
+          cmake --build --preset $(cmake.preset)
+        displayName: "CMake: Configure/Build(vcvarsall)"
       - task: CMake@1
         displayName: "CMake: Install"
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,10 +92,10 @@ jobs:
       matrix:
         debug_x86:
           vcvars.arg: x86
-          cmake.preset: x86-clang-debug-vs2019
+          cmake.preset: x86-clang-debug
         debug_x64:
           vcvars.arg: x64
-          cmake.preset: x64-clang-debug-vs2019
+          cmake.preset: x64-clang-debug
     steps:
       - task: ChocolateyCommand@0
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,8 +54,10 @@ jobs:
     strategy:
       matrix:
         debug_x86:
+          vcvars.arg: x86
           cmake.preset: x86-clang-debug
         debug_x64:
+          vcvars.arg: x64
           cmake.preset: x64-clang-debug
     steps:
       - task: ChocolateyCommand@0
@@ -64,18 +66,17 @@ jobs:
           installPackageId: "ninja"
           installInstallArgs: "--no-progress --yes"
       # see https://www.cicoria.com/using-vcvars64-vcvars-bat-from-powershell-and-azure-devops/
-      # see https://github.com/Microsoft/azure-pipelines-tasks/issues/9737
       - powershell: |
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           $installPath = &$vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
-          # &$installPath\VC\Auxiliary\Build\vcvarsall.bat x86
           echo "##vso[task.setvariable variable=vcvarsPath;isOutput=true]$installPath\VC\Auxiliary\Build\vcvarsall.bat"
         name: detected
         displayName: "PowerShell: Search vcvarsall.bat"
-      - powershell: |
-          Write-Output $detected.vcvarsPath
-          & $detected.vcvarsPath x86
-          cmake --preset x86-clang-debug -DCMAKE_INSTALL_PREFIX:PATH="$(Build.ArtifactStagingDirectory)"
+      # see https://github.com/Microsoft/azure-pipelines-tasks/issues/9737
+      - script: | # using Cmdlet
+          echo $(detected.vcvarsPath)
+          call "$(detected.vcvarsPath)" $(vcvars.arg)
+          cmake --preset $(cmake.preset) -DCMAKE_INSTALL_PREFIX:PATH="$(Build.ArtifactStagingDirectory)"
         displayName: "CMake: Configure(vcvarsall)"
       - task: CMake@1
         displayName: "CMake: Build"


### PR DESCRIPTION
### Changes

* Search `vcvarsall.bat` with the PowerShell. Set the output variable to forward the script file's path.
* Use `vcvarsall.bat` with `script`(cmdlet) task, then invoke CMake for configure/build

### References

* https://www.cicoria.com/using-vcvars64-vcvars-bat-from-powershell-and-azure-devops/
* https://github.com/Microsoft/azure-pipelines-tasks/issues/9737
